### PR TITLE
use dev mode for containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ RUN npm ci
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+
 
 EXPOSE 3000
 

--- a/Containerfile
+++ b/Containerfile
@@ -7,13 +7,8 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+COPY package.json package-lock.json* ./
+RUN npm ci
 
 
 # Rebuild the source code only when needed
@@ -22,47 +17,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED=1
-
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
-
-# Production image, copy all the files and run next
-FROM base AS runner
-WORKDIR /app
-
-ENV NODE_ENV=production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED=1
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/public ./public
-
-# Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
-
 EXPOSE 3000
 
 ENV PORT=3000
 
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
-CMD ["node", "server.js"]
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ To start in dev mode, use:
 
 #### Container approach
 
-To run in containerd instead, build the image with `nerdctl build -t web-dashboard .`
-then `run` with `nerdctl run -p 3000:3000 web-dashboard`
-
-to pass the WS URL to the container, run with `-e NEXT_PUBLIC_WS_URL=ws://<hostname>:<port>/pvws/pv`
+To run in containerd instead, run `nerdctl compose -f compose.yaml up`. This will mount your current directory as a volume in the container which means any changes will make nextjs re-compile pages. This also means that anything in the `dotenv` files are picked up, including PVWS URL.
 
 ### Building
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  webdash:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  webpack (config, {dev}) {
+    if (dev) {
+        config.watchOptions = {
+            poll: true
+        }
+    }
+    return config
+},
   reactStrictMode: true,
   output: "export",
   basePath: "/WebDashboard",

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack (config, {dev}) {
+  webpack(config, { dev }) {
     if (dev) {
-        config.watchOptions = {
-            poll: true
-        }
+      config.watchOptions = {
+        poll: true,
+      };
     }
-    return config
-},
+    return config;
+  },
   reactStrictMode: true,
   output: "export",
   basePath: "/WebDashboard",


### PR DESCRIPTION
Fix the containerfile by just using npm run dev rather than trying to get the static output. we aren't using the containerfile for deployment as that's handled by the CI workflow, so the containers are just for development. 

instructions should be the same for running. 

I also had a go at creating a vs code devcontainer but it doesn't look like there is official support yet for nerdctl..? https://github.com/microsoft/vscode-remote-release/issues/6014 