### PR TITLE
Show update timestamps

### DIFF
--- a/app/components/Block.test.tsx
+++ b/app/components/Block.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import Block from "@/app/components/Block";
 import { IfcBlock } from "@/app/types";
 
@@ -20,12 +20,7 @@ it("renders topbar unchanged", () => {
   };
   const instName = "Instrument";
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={instName}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={instName} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -36,12 +31,7 @@ it("renders topbar unchanged", () => {
 it("renders nothing if pv is hidden", () => {
   const aBlock: IfcBlock = { pvaddress: "SOME:PV", visible: false };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -56,12 +46,7 @@ it("renders block with correct name", () => {
     human_readable_name: "MyBlock",
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -80,12 +65,7 @@ it("renders block with run control that is in range as a tick", () => {
     runcontrol_enabled: true,
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -105,12 +85,7 @@ it("renders block with run control that is not in range as a cross", () => {
     runcontrol_enabled: true,
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -130,12 +105,7 @@ it("renders block without run control without tick or cross", () => {
     runcontrol_enabled: false,
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
@@ -159,19 +129,49 @@ it("renders block with SP and shows SP value", () => {
     value: expectedValue,
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={true}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },
   );
+  const valueSpan = container.querySelector(
+    `#${aBlock.human_readable_name}_VALUE`,
+  )!;
+
+  fireEvent.click(valueSpan);
+  expect(valueSpan.innerHTML).toContain(`${expectedValue}`);
   expect(
-    container.querySelector(`#${aBlock.human_readable_name}_VALUE`)!.innerHTML,
-  ).toContain(`${expectedValue} <br>(SP: ${expectedSpValue})`);
+    container.querySelector(`#${aBlock.human_readable_name}_SP`)!.innerHTML,
+  ).toContain(expectedSpValue.toString());
+});
+
+it("renders block with timestamp and shows timestamp value", () => {
+  const expectedValue = 123;
+  const expectedTimeStamp = 1731342022;
+  const aBlock: IfcBlock = {
+    pvaddress: "SOME:PV",
+    visible: true,
+    human_readable_name: "MyBlock",
+    runcontrol_inrange: false,
+    runcontrol_enabled: false,
+    updateSeconds: expectedTimeStamp,
+    value: expectedValue,
+  };
+  const { container } = render(
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
+    {
+      container: tableBody,
+    },
+  );
+  const valueSpan = container.querySelector(
+    `#${aBlock.human_readable_name}_VALUE`,
+  )!;
+  fireEvent.click(valueSpan);
+  expect(valueSpan.innerHTML).toContain(`${expectedValue}`);
+  expect(
+    container.querySelector(`#${aBlock.human_readable_name}_TIMESTAMP`)!
+      .innerHTML,
+  ).toContain(new Date(expectedTimeStamp * 1000).toLocaleString());
 });
 
 it("renders block without SP and hides SP value", () => {
@@ -187,12 +187,7 @@ it("renders block without SP and hides SP value", () => {
     sp_value: expectedSpValue,
   };
   const { container } = render(
-    <Block
-      pv={aBlock}
-      instName={""}
-      showHiddenBlocks={false}
-      showSetpoints={false}
-    />,
+    <Block pv={aBlock} instName={""} showHiddenBlocks={false} />,
     {
       container: tableBody,
     },

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -66,7 +66,7 @@ export default function Block({
           <div className="flex justify-between">
             <span
               id={pv.human_readable_name + "_VALUE"}
-              className={pv.severity != "NONE" ? "text-red-600" : ""}
+              className={pv.severity != "NONE" ? "text-red-400" : ""}
             >
               {showAdvanced && "Readback: "}
               {pv.value} {pv.units != null && pv.units}
@@ -88,7 +88,7 @@ export default function Block({
               {pv.severity != "NONE" ? (
                 <a
                   href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
-                  className="text-red-600"
+                  className="text-red-400"
                 >
                   Alarm: {pv.severity}
                 </a>

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { IfcBlock } from "@/app/types";
-import { useState } from "react";
+import React, { useState } from "react";
 
 const grafana_stub =
   "https://shadow.nd.rl.ac.uk/grafana/d/wMlwwaHMk/block-history?viewPanel=2&orgId=1&var-block=";
@@ -9,18 +9,15 @@ export default function Block({
   pv,
   instName,
   showHiddenBlocks,
-  showSetpoints,
-  showTimestamps,
 }: {
   pv: IfcBlock;
   instName: string;
   showHiddenBlocks: boolean;
-  showSetpoints: boolean;
-  showTimestamps: boolean;
 }) {
   const [currentValue, setCurrentValue] = useState<
     string | number | undefined
   >();
+  const [showAdvanced, setShowAdvanced] = useState(false);
   if (!pv.visible && !showHiddenBlocks && !instName) {
     return null;
   }
@@ -44,6 +41,9 @@ export default function Block({
     <tr
       key={pv.human_readable_name}
       className="border-b border-blue-gray-200 transition duration-100 hover:bg-gray-100 hover:text-black"
+      onClick={() => {
+        setShowAdvanced(!showAdvanced);
+      }}
     >
       <td className="py-1 px-4">
         <a
@@ -62,19 +62,8 @@ export default function Block({
 
       <td className="py-1 px-4 ">
         <span id={pv.human_readable_name + "_VALUE"}>
+          {showAdvanced && "Readback: "}
           {pv.value} {pv.units != null && pv.units}
-          {showSetpoints && pv.sp_value != null ? (
-            <>
-              <br />
-              {`(SP: ${pv.sp_value})`}
-            </>
-          ) : null}
-          {showTimestamps && pv.updateSeconds != null ? (
-            <>
-              <br />
-              {`(Last update: ${new Date(pv.updateSeconds * 1000).toLocaleString()})`}
-            </>
-          ) : null}
           {pv.severity != "NONE" ? (
             <a
               href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
@@ -84,6 +73,22 @@ export default function Block({
               {pv.severity}
             </a>
           ) : null}
+          {showAdvanced && (
+            <div>
+              <hr />
+              {pv.sp_value != null ? (
+                <span id={pv.human_readable_name + "_SP"}>
+                  {`Setpoint: ${pv.sp_value}`}
+                  <hr />
+                </span>
+              ) : null}
+              {pv.updateSeconds != null ? (
+                <span id={pv.human_readable_name + "_TIMESTAMP"}>
+                  {`Last update: ${new Date(pv.updateSeconds * 1000).toLocaleString()}`}
+                </span>
+              ) : null}
+            </div>
+          )}
         </span>
       </td>
       <td className="py-1 px-4 flex justify-between items-center">
@@ -99,6 +104,9 @@ export default function Block({
         >
           <circle cx="12" cy="12" r="12" />
         </svg>
+        <span className={"cursor-pointer font-bold"}>
+          {showAdvanced ? "-" : "+"}
+        </span>
       </td>
     </tr>
   );

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -10,11 +10,13 @@ export default function Block({
   instName,
   showHiddenBlocks,
   showSetpoints,
+  showTimestamps,
 }: {
   pv: IfcBlock;
   instName: string;
   showHiddenBlocks: boolean;
   showSetpoints: boolean;
+  showTimestamps: boolean;
 }) {
   const [currentValue, setCurrentValue] = useState<
     string | number | undefined
@@ -65,6 +67,12 @@ export default function Block({
             <>
               <br />
               {`(SP: ${pv.sp_value})`}
+            </>
+          ) : null}
+          {showTimestamps && pv.updateSeconds != null ? (
+            <>
+              <br />
+              {`(Last update: ${new Date(pv.updateSeconds * 1000).toLocaleString()})`}
             </>
           ) : null}
           {pv.severity != "NONE" ? (

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -45,7 +45,7 @@ export default function Block({
         setShowAdvanced(!showAdvanced);
       }}
     >
-      <td className="py-1 px-4">
+      <td className="py-1 px-2 w-1/3">
         <a
           className="underline"
           href={
@@ -60,7 +60,7 @@ export default function Block({
         </a>
       </td>
 
-      <td className="py-1 px-4 ">
+      <td className="py-1 px-2 w-1/3">
         <span id={pv.human_readable_name + "_VALUE"}>
           {showAdvanced && "Readback: "}
           {pv.value} {pv.units != null && pv.units}
@@ -91,7 +91,7 @@ export default function Block({
           )}
         </span>
       </td>
-      <td className="py-1 px-4 flex justify-between items-center">
+      <td className="py-1 px-2  flex justify-between items-center">
         <span id={pv.human_readable_name + "_VALUE_RC"}>
           {pv.runcontrol_enabled && (pv.runcontrol_inrange ? "✅" : "❌")}
         </span>

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -64,7 +64,10 @@ export default function Block({
       <td className="py-1 px-2 w-7/12">
         <span id={pv.human_readable_name + "_VALUE_ROW"}>
           <div className="flex justify-between">
-            <span id={pv.human_readable_name + "_VALUE"}>
+            <span
+              id={pv.human_readable_name + "_VALUE"}
+              className={pv.severity != "NONE" ? "text-red-600" : ""}
+            >
               {showAdvanced && "Readback: "}
               {pv.value} {pv.units != null && pv.units}
             </span>
@@ -78,16 +81,18 @@ export default function Block({
               <circle cx="12" cy="12" r="12" />
             </svg>
           </div>
-          {pv.severity != "NONE" ? (
-            <a
-              href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
-              className="text-red-600"
-            >
-              Alarm: {pv.severity}
-            </a>
-          ) : null}
+
           {showAdvanced && (
             <div>
+              <hr />
+              {pv.severity != "NONE" ? (
+                <a
+                  href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
+                  className="text-red-600"
+                >
+                  Alarm: {pv.severity}
+                </a>
+              ) : null}
               <hr />
               {pv.sp_value != null ? (
                 <span id={pv.human_readable_name + "_SP"}>

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -37,6 +37,7 @@ export default function Block({
     }, 2000);
   }
 
+  const minimum_date_to_be_shown = 631152000; // This is what PVWS thinks epoch time is for some reason. don't bother showing it as the instrument wasn't running EPICS on 01/01/1990
   return (
     <tr
       key={pv.human_readable_name}
@@ -45,7 +46,7 @@ export default function Block({
         setShowAdvanced(!showAdvanced);
       }}
     >
-      <td className="py-1 px-2 w-1/3">
+      <td className="py-1 px-2 w-1/3 flex-row">
         <a
           className="underline"
           href={
@@ -60,17 +61,29 @@ export default function Block({
         </a>
       </td>
 
-      <td className="py-1 px-2 w-1/3">
-        <span id={pv.human_readable_name + "_VALUE"}>
-          {showAdvanced && "Readback: "}
-          {pv.value} {pv.units != null && pv.units}
+      <td className="py-1 px-2 w-7/12">
+        <span id={pv.human_readable_name + "_VALUE_ROW"}>
+          <div className="flex justify-between">
+            <span id={pv.human_readable_name + "_VALUE"}>
+              {showAdvanced && "Readback: "}
+              {pv.value} {pv.units != null && pv.units}
+            </span>
+            <svg
+              id={pv.human_readable_name + "_CIRCLE"}
+              className="min-w-2 min-h-2 max-w-2 max-h-2 transition-all text-transparent"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <circle cx="12" cy="12" r="12" />
+            </svg>
+          </div>
           {pv.severity != "NONE" ? (
             <a
               href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
               className="text-red-600"
             >
-              <br />
-              {pv.severity}
+              Alarm: {pv.severity}
             </a>
           ) : null}
           {showAdvanced && (
@@ -82,8 +95,10 @@ export default function Block({
                   <hr />
                 </span>
               ) : null}
-              {pv.updateSeconds != null ? (
+              {pv.updateSeconds != null &&
+              pv.updateSeconds > minimum_date_to_be_shown ? (
                 <span id={pv.human_readable_name + "_TIMESTAMP"}>
+                  {/*Multiply by 1000 here as Date() expects milliseconds*/}
                   {`Last update: ${new Date(pv.updateSeconds * 1000).toLocaleString()}`}
                 </span>
               ) : null}
@@ -92,19 +107,17 @@ export default function Block({
         </span>
       </td>
       <td className="py-1 px-2  flex justify-between items-center">
-        <span id={pv.human_readable_name + "_VALUE_RC"}>
+        <span
+          id={pv.human_readable_name + "_VALUE_RC"}
+          title={"Run control in-range?"}
+        >
           {pv.runcontrol_enabled && (pv.runcontrol_inrange ? "✅" : "❌")}
         </span>
-        <svg
-          id={pv.human_readable_name + "_CIRCLE"}
-          className="min-w-2 min-h-2 max-w-2 max-h-2 transition-all text-transparent"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="currentColor"
-          viewBox="0 0 24 24"
+
+        <span
+          className={"cursor-pointer font-bold"}
+          title={"Show/Hide advanced statuses"}
         >
-          <circle cx="12" cy="12" r="12" />
-        </svg>
-        <span className={"cursor-pointer font-bold"}>
           {showAdvanced ? "-" : "+"}
         </span>
       </td>

--- a/app/components/Group.tsx
+++ b/app/components/Group.tsx
@@ -28,14 +28,14 @@ export default function Group({
         {group.name}
       </h1>
       <table className="text-sm table-fixed">
-        <thead>
-          <tr className="bg-blue-gray-100 text-gray-100">
-            <th className="py-3 px-4 text-left">Block</th>
-            <th className="py-3 px-4 text-left">Value</th>
-            <th className="py-3 px-4 text-left">In-Range</th>
+        <thead className="sticky">
+          <tr className="bg-blue-gray-100 text-gray-100 border-b-2 border-b-gray-400">
+            <th className="py-2 px-2 text-left w-1/3">Block</th>
+            <th className="py-2 px-2 text-left w-1/3">Value</th>
+            <th className="py-2 px-2 text-left w-1/3">In-Range</th>
           </tr>
         </thead>
-        <tbody className="text-gray-200 ">
+        <tbody className="text-gray-200 sticky">
           {group.blocks.map((pv) => {
             return (
               <Block

--- a/app/components/Group.tsx
+++ b/app/components/Group.tsx
@@ -31,8 +31,8 @@ export default function Group({
         <thead className="sticky">
           <tr className="bg-blue-gray-100 text-gray-100 border-b-2 border-b-gray-400">
             <th className="py-2 px-2 text-left w-1/3">Block</th>
-            <th className="py-2 px-2 text-left w-1/3">Value</th>
-            <th className="py-2 px-2 text-left w-1/3">In-Range</th>
+            <th className="py-2 px-2 text-left w-7/12">Value</th>
+            <th className="py-2 px-2 text-left"></th>
           </tr>
         </thead>
         <tbody className="text-gray-200 sticky">

--- a/app/components/Group.tsx
+++ b/app/components/Group.tsx
@@ -9,11 +9,13 @@ export default function Group({
   instName,
   showHiddenBlocks,
   showSetpoints,
+  showTimestamps,
 }: {
   group: IfcGroup;
   instName: string;
   showHiddenBlocks: boolean;
   showSetpoints: boolean;
+  showTimestamps: boolean;
 }) {
   if (!group) {
     return <h1>Loading...</h1>;
@@ -46,6 +48,7 @@ export default function Group({
                 instName={instName}
                 showHiddenBlocks={showHiddenBlocks}
                 showSetpoints={showSetpoints}
+                showTimestamps={showTimestamps}
               />
             );
           })}

--- a/app/components/Group.tsx
+++ b/app/components/Group.tsx
@@ -8,14 +8,10 @@ export default function Group({
   group,
   instName,
   showHiddenBlocks,
-  showSetpoints,
-  showTimestamps,
 }: {
   group: IfcGroup;
   instName: string;
   showHiddenBlocks: boolean;
-  showSetpoints: boolean;
-  showTimestamps: boolean;
 }) {
   if (!group) {
     return <h1>Loading...</h1>;
@@ -47,8 +43,6 @@ export default function Group({
                 pv={pv}
                 instName={instName}
                 showHiddenBlocks={showHiddenBlocks}
-                showSetpoints={showSetpoints}
-                showTimestamps={showTimestamps}
               />
             );
           })}

--- a/app/components/Groups.tsx
+++ b/app/components/Groups.tsx
@@ -17,7 +17,7 @@ export default function Groups({
   }
 
   return (
-    <div className="rounded-xl grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3  gap-4 mt-2">
+    <div className="rounded-xl grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mt-2">
       {groupsMap.map((group) => {
         return (
           <Group

--- a/app/components/Groups.tsx
+++ b/app/components/Groups.tsx
@@ -8,11 +8,13 @@ export default function Groups({
   instName,
   showHiddenBlocks,
   showSetpoints,
+  showTimestamps,
 }: {
   groupsMap: Array<IfcGroup>;
   instName: string;
   showHiddenBlocks: boolean;
   showSetpoints: boolean;
+  showTimestamps: boolean;
 }) {
   if (!groupsMap) {
     return <h1>Loading...</h1>;
@@ -28,6 +30,7 @@ export default function Groups({
             instName={instName}
             showHiddenBlocks={showHiddenBlocks}
             showSetpoints={showSetpoints}
+            showTimestamps={showTimestamps}
           />
         );
       })}

--- a/app/components/Groups.tsx
+++ b/app/components/Groups.tsx
@@ -7,14 +7,10 @@ export default function Groups({
   groupsMap,
   instName,
   showHiddenBlocks,
-  showSetpoints,
-  showTimestamps,
 }: {
   groupsMap: Array<IfcGroup>;
   instName: string;
   showHiddenBlocks: boolean;
-  showSetpoints: boolean;
-  showTimestamps: boolean;
 }) {
   if (!groupsMap) {
     return <h1>Loading...</h1>;
@@ -29,8 +25,6 @@ export default function Groups({
             group={group}
             instName={instName}
             showHiddenBlocks={showHiddenBlocks}
-            showSetpoints={showSetpoints}
-            showTimestamps={showTimestamps}
           />
         );
       })}

--- a/app/components/InstrumentPage.tsx
+++ b/app/components/InstrumentPage.tsx
@@ -276,23 +276,11 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
           setChecked={setShowHiddenBlocks}
           text={"Show hidden blocks"}
         />
-        <CheckToggle
-          checked={showSetpoints}
-          setChecked={setShowSetpoints}
-          text={"Show setpoints"}
-        />
-        <CheckToggle
-          checked={showTimestamps}
-          setChecked={setShowTimestamps}
-          text={"Show update timestamps"}
-        />
       </div>
       <Groups
         groupsMap={currentInstrument.groups}
         instName={instName}
         showHiddenBlocks={showHiddenBlocks}
-        showSetpoints={showSetpoints}
-        showTimestamps={showTimestamps}
       />
     </div>
   );

--- a/app/components/InstrumentPage.tsx
+++ b/app/components/InstrumentPage.tsx
@@ -264,7 +264,7 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
     return <h1>Loading...</h1>;
   }
   return (
-    <div className="p-2 md:p-8 w-full mx-auto">
+    <div className="p-2 w-full mx-auto">
       <TopBar
         dashboard={currentInstrument.dashboard}
         instName={instName}

--- a/app/components/InstrumentPage.tsx
+++ b/app/components/InstrumentPage.tsx
@@ -264,7 +264,7 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
     return <h1>Loading...</h1>;
   }
   return (
-    <div className="p-8 w-full mx-auto max-w-7xl">
+    <div className="p-2 md:p-8 w-full mx-auto">
       <TopBar
         dashboard={currentInstrument.dashboard}
         instName={instName}

--- a/app/components/InstrumentPage.tsx
+++ b/app/components/InstrumentPage.tsx
@@ -99,6 +99,7 @@ export function toPrecision(
 function InstrumentData({ instrumentName }: { instrumentName: string }) {
   const [showHiddenBlocks, setShowHiddenBlocks] = useState(false);
   const [showSetpoints, setShowSetpoints] = useState(false);
+  const [showTimestamps, setShowTimestamps] = useState(false);
   const CONFIG_DETAILS = "CS:BLOCKSERVER:GET_CURR_CONFIG_DETAILS";
   const [instlist, setInstlist] = useState<Array<any> | null>(null);
   const [currentInstrument, setCurrentInstrument] = useState<Instrument | null>(
@@ -242,6 +243,7 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
               }
               // if a block has precision truncate it here
               block.value = toPrecision(block, pvVal);
+              if (updatedPV.seconds) block.updateSeconds = updatedPV.seconds;
 
               if (updatedPV.units) block.units = updatedPV.units;
               if (updatedPV.severity) block.severity = updatedPV.severity;
@@ -268,7 +270,7 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
         instName={instName}
         runInfoPVs={currentInstrument.runInfoPVs}
       />
-      <div className="flex gap-2 ml-2">
+      <div className="flex gap-2 ml-2 md:flex-row flex-col">
         <CheckToggle
           checked={showHiddenBlocks}
           setChecked={setShowHiddenBlocks}
@@ -279,12 +281,18 @@ function InstrumentData({ instrumentName }: { instrumentName: string }) {
           setChecked={setShowSetpoints}
           text={"Show setpoints"}
         />
+        <CheckToggle
+          checked={showTimestamps}
+          setChecked={setShowTimestamps}
+          text={"Show update timestamps"}
+        />
       </div>
       <Groups
         groupsMap={currentInstrument.groups}
         instName={instName}
         showHiddenBlocks={showHiddenBlocks}
         showSetpoints={showSetpoints}
+        showTimestamps={showTimestamps}
       />
     </div>
   );

--- a/app/components/TopBar.test.ts
+++ b/app/components/TopBar.test.ts
@@ -47,7 +47,7 @@ it("draws instName expectedly", () => {
       runInfoPVs: instrument.runInfoPVs,
     }),
   );
-  expect(container.querySelector("#instNameSpan")!.innerHTML).toBe(
+  expect(container.querySelector("#instNameLabel")!.innerHTML).toContain(
     instName.toUpperCase(),
   );
 });

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -67,7 +67,7 @@ export default function TopBar({
           </span>
         </h3>
 
-        <div className="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col max-w-full w-full">
+        <div className="bg-gray-50 border-2 border-gray-200 flex flex-col max-w-full w-full">
           <table
             id={"dashboardTable"}
             className="text-sm max-w-full table-fixed flex divide-x divide-gray-200 text-wrap "
@@ -96,7 +96,7 @@ export default function TopBar({
 
         <label id={"runInfoLabel"} className="p-2 w-full">
           <input className="peer/showLabel absolute scale-0" type="checkbox" />
-          <span className="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center">
+          <span className="block max-h-14 overflow-hidden rounded-lg bg-gray-600 hover:bg-gray-800 text-white px-4 py-0 mb-2 transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center">
             <h3 className="flex h-14 cursor-pointer font-bold text-center items-center justify-center">
               Show/hide all run information
             </h3>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -42,22 +42,6 @@ export default function TopBar({
       id="top_bar"
       className="w-full bg-white  shadow-lg text-black rounded-xl text-md"
     >
-      <div className="text-left mb-4 p-4">
-        <h1 className="text-black text-2xl">
-          Instrument:{" "}
-          <span id={"instNameSpan"} className="font-semibold">
-            {instName.toUpperCase()}
-          </span>
-        </h1>
-        <h1 className="text-black text-lg">
-          Config:{" "}
-          <span id={"configNameSpan"} className="font-semibold">
-            {findPVByHumanReadableName(runInfoPVs, configName)
-              ? findPVByHumanReadableName(runInfoPVs, configName)!.value
-              : "UNKNOWN"}
-          </span>
-        </h1>
-      </div>
       <div
         id="instNameDiv"
         className="w-full flex justify-center items-center flex-col"
@@ -69,11 +53,21 @@ export default function TopBar({
            ${getForegroundColour(getRunstate(runInfoPVs))}
           
           `}
+          id={"instNameLabel"}
         >
           {instName.toUpperCase()} is{" "}
           <span id={"runStateSpan"}>{getRunstate(runInfoPVs)}</span>
         </h2>
-        <div className="bg-gray-50 border-2 border-gray-800 m-4 p-4 shadow-md flex flex-col">
+        <h3 className="text-black text-wrap max-w-full break-all">
+          Config:{" "}
+          <span id={"configNameSpan"} className="font-semibold">
+            {findPVByHumanReadableName(runInfoPVs, configName)
+              ? findPVByHumanReadableName(runInfoPVs, configName)!.value
+              : "UNKNOWN"}
+          </span>
+        </h3>
+
+        <div className="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col">
           <table
             id={"dashboardTable"}
             className="text-sm w-full table-fixed flex divide-x divide-gray-200 "
@@ -98,11 +92,14 @@ export default function TopBar({
           </table>
         </div>
 
-        <label id={"runInfoLabel"}>
+        <label
+          id={"runInfoLabel"}
+          className="pt-2 max-w-full break-all text-wrap"
+        >
           <input className="peer/showLabel absolute scale-0" type="checkbox" />
           <span className="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer">
             <h3 className="flex h-14 cursor-pointer items-center font-bold ">
-              Click to show/hide all run information
+              Show/hide all run information
             </h3>
             {runInfoPVs.map((runInfoPV) => (
               <p className="mb-2" key={runInfoPV.human_readable_name}>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -58,29 +58,31 @@ export default function TopBar({
           {instName.toUpperCase()} is{" "}
           <span id={"runStateSpan"}>{getRunstate(runInfoPVs)}</span>
         </h2>
-        <h3 className="text-black text-wrap max-w-full break-all">
+        <h3 className="text-black text-wrap max-w-full break-all py-2 font-semibold">
           Config:{" "}
-          <span id={"configNameSpan"} className="font-semibold">
+          <span id={"configNameSpan"}>
             {findPVByHumanReadableName(runInfoPVs, configName)
               ? findPVByHumanReadableName(runInfoPVs, configName)!.value
               : "UNKNOWN"}
           </span>
         </h3>
 
-        <div className="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col">
+        <div className="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col max-w-full w-full">
           <table
             id={"dashboardTable"}
-            className="text-sm w-full table-fixed flex divide-x divide-gray-200 "
+            className="text-sm max-w-full table-fixed flex divide-x divide-gray-200 text-wrap "
           >
             {dashboard.map((column: Array<Array<IfcPV>>, index: number) => (
-              <tbody key={index} id={index.toString()}>
+              <tbody key={index} id={index.toString()} className="w-1/3">
                 {column.map((row: Array<IfcPV>, index: number) => (
                   <tr
                     key={index}
-                    className="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+                    className="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
                   >
-                    <td className="py-1 px-4 flex font-bold">{row[0].value}</td>
-                    <td className="py-1 px-4 flex justify-between items-center">
+                    <td className="py-1 px-4 flex font-bold break-words">
+                      {row[0].value}
+                    </td>
+                    <td className="py-1 px-4 flex justify-between items-center break-all">
                       <span className="font-light">
                         {row[1].value != null ? row[1].value : "Hidden/unknown"}
                       </span>
@@ -92,20 +94,23 @@ export default function TopBar({
           </table>
         </div>
 
-        <label
-          id={"runInfoLabel"}
-          className="pt-2 max-w-full break-all text-wrap"
-        >
+        <label id={"runInfoLabel"} className="p-2 w-full">
           <input className="peer/showLabel absolute scale-0" type="checkbox" />
-          <span className="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer">
-            <h3 className="flex h-14 cursor-pointer items-center font-bold ">
+          <span className="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center">
+            <h3 className="flex h-14 cursor-pointer font-bold text-center items-center justify-center">
               Show/hide all run information
             </h3>
-            {runInfoPVs.map((runInfoPV) => (
-              <p className="mb-2" key={runInfoPV.human_readable_name}>
-                {runInfoPV.human_readable_name}: {runInfoPV.value}
-              </p>
-            ))}
+            <div className="grid md:grid-cols-5 gap-2">
+              {runInfoPVs.map((runInfoPV) => (
+                <div
+                  className="mb-2 shadow-sm rounded-md"
+                  key={runInfoPV.human_readable_name}
+                >
+                  <p className="font-bold">{runInfoPV.human_readable_name}:</p>{" "}
+                  <p className="break-all">{runInfoPV.value}</p>
+                </div>
+              ))}
+            </div>
           </span>
         </label>
       </div>

--- a/app/components/__snapshots__/Block.test.tsx.snap
+++ b/app/components/__snapshots__/Block.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`renders topbar unchanged 1`] = `
           class="flex justify-between"
         >
           <span
+            class="text-red-600"
             id="undefined_VALUE"
           >
             123
@@ -44,12 +45,6 @@ exports[`renders topbar unchanged 1`] = `
             />
           </svg>
         </div>
-        <a
-          class="text-red-600"
-          href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
-        >
-          Alarm: 
-        </a>
       </span>
     </td>
     <td

--- a/app/components/__snapshots__/Block.test.tsx.snap
+++ b/app/components/__snapshots__/Block.test.tsx.snap
@@ -50,6 +50,11 @@ exports[`renders topbar unchanged 1`] = `
           r="12"
         />
       </svg>
+      <span
+        class="cursor-pointer font-bold"
+      >
+        +
+      </span>
     </td>
   </tr>
 </tbody>

--- a/app/components/__snapshots__/Block.test.tsx.snap
+++ b/app/components/__snapshots__/Block.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders topbar unchanged 1`] = `
     class="border-b border-blue-gray-200 transition duration-100 hover:bg-gray-100 hover:text-black"
   >
     <td
-      class="py-1 px-2 w-1/3"
+      class="py-1 px-2 w-1/3 flex-row"
     >
       <a
         class="underline"
@@ -15,19 +15,40 @@ exports[`renders topbar unchanged 1`] = `
       />
     </td>
     <td
-      class="py-1 px-2 w-1/3"
+      class="py-1 px-2 w-7/12"
     >
       <span
-        id="undefined_VALUE"
+        id="undefined_VALUE_ROW"
       >
-        123
-         
-        mm
+        <div
+          class="flex justify-between"
+        >
+          <span
+            id="undefined_VALUE"
+          >
+            123
+             
+            mm
+          </span>
+          <svg
+            class="min-w-2 min-h-2 max-w-2 max-h-2 transition-all text-transparent"
+            fill="currentColor"
+            id="undefined_CIRCLE"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="12"
+            />
+          </svg>
+        </div>
         <a
           class="text-red-600"
           href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
         >
-          <br />
+          Alarm: 
         </a>
       </span>
     </td>
@@ -36,22 +57,11 @@ exports[`renders topbar unchanged 1`] = `
     >
       <span
         id="undefined_VALUE_RC"
+        title="Run control in-range?"
       />
-      <svg
-        class="min-w-2 min-h-2 max-w-2 max-h-2 transition-all text-transparent"
-        fill="currentColor"
-        id="undefined_CIRCLE"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle
-          cx="12"
-          cy="12"
-          r="12"
-        />
-      </svg>
       <span
         class="cursor-pointer font-bold"
+        title="Show/Hide advanced statuses"
       >
         +
       </span>

--- a/app/components/__snapshots__/Block.test.tsx.snap
+++ b/app/components/__snapshots__/Block.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders topbar unchanged 1`] = `
     class="border-b border-blue-gray-200 transition duration-100 hover:bg-gray-100 hover:text-black"
   >
     <td
-      class="py-1 px-4"
+      class="py-1 px-2 w-1/3"
     >
       <a
         class="underline"
@@ -15,7 +15,7 @@ exports[`renders topbar unchanged 1`] = `
       />
     </td>
     <td
-      class="py-1 px-4 "
+      class="py-1 px-2 w-1/3"
     >
       <span
         id="undefined_VALUE"
@@ -32,7 +32,7 @@ exports[`renders topbar unchanged 1`] = `
       </span>
     </td>
     <td
-      class="py-1 px-4 flex justify-between items-center"
+      class="py-1 px-2  flex justify-between items-center"
     >
       <span
         id="undefined_VALUE_RC"

--- a/app/components/__snapshots__/Block.test.tsx.snap
+++ b/app/components/__snapshots__/Block.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renders topbar unchanged 1`] = `
           class="flex justify-between"
         >
           <span
-            class="text-red-600"
+            class="text-red-400"
             id="undefined_VALUE"
           >
             123

--- a/app/components/__snapshots__/TopBar.test.ts.snap
+++ b/app/components/__snapshots__/TopBar.test.ts.snap
@@ -38,7 +38,7 @@ exports[`renders topbar unchanged 1`] = `
         />
       </h3>
       <div
-        class="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col max-w-full w-full"
+        class="bg-gray-50 border-2 border-gray-200 flex flex-col max-w-full w-full"
       >
         <table
           class="text-sm max-w-full table-fixed flex divide-x divide-gray-200 text-wrap "
@@ -202,7 +202,7 @@ exports[`renders topbar unchanged 1`] = `
           type="checkbox"
         />
         <span
-          class="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center"
+          class="block max-h-14 overflow-hidden rounded-lg bg-gray-600 hover:bg-gray-800 text-white px-4 py-0 mb-2 transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center"
         >
           <h3
             class="flex h-14 cursor-pointer font-bold text-center items-center justify-center"

--- a/app/components/__snapshots__/TopBar.test.ts.snap
+++ b/app/components/__snapshots__/TopBar.test.ts.snap
@@ -29,35 +29,35 @@ exports[`renders topbar unchanged 1`] = `
         </span>
       </h2>
       <h3
-        class="text-black text-wrap max-w-full break-all"
+        class="text-black text-wrap max-w-full break-all py-2 font-semibold"
       >
         Config:
          
         <span
-          class="font-semibold"
           id="configNameSpan"
         />
       </h3>
       <div
-        class="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col"
+        class="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col max-w-full w-full"
       >
         <table
-          class="text-sm w-full table-fixed flex divide-x divide-gray-200 "
+          class="text-sm max-w-full table-fixed flex divide-x divide-gray-200 text-wrap "
           id="dashboardTable"
         >
           <tbody
+            class="w-1/3"
             id="0"
           >
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               >
                 Title:
               </td>
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -67,15 +67,15 @@ exports[`renders topbar unchanged 1`] = `
               </td>
             </tr>
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               >
                 Users:
               </td>
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -86,16 +86,17 @@ exports[`renders topbar unchanged 1`] = `
             </tr>
           </tbody>
           <tbody
+            class="w-1/3"
             id="1"
           >
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -105,13 +106,13 @@ exports[`renders topbar unchanged 1`] = `
               </td>
             </tr>
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -121,13 +122,13 @@ exports[`renders topbar unchanged 1`] = `
               </td>
             </tr>
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -138,16 +139,17 @@ exports[`renders topbar unchanged 1`] = `
             </tr>
           </tbody>
           <tbody
+            class="w-1/3"
             id="2"
           >
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -157,13 +159,13 @@ exports[`renders topbar unchanged 1`] = `
               </td>
             </tr>
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -173,13 +175,13 @@ exports[`renders topbar unchanged 1`] = `
               </td>
             </tr>
             <tr
-              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white"
+              class="[&:not(:last-child)]:border-b border-gray-300 text-black transition duration-100 hover:bg-gray-700 hover:text-white md:flex"
             >
               <td
-                class="py-1 px-4 flex font-bold"
+                class="py-1 px-4 flex font-bold break-words"
               />
               <td
-                class="py-1 px-4 flex justify-between items-center"
+                class="py-1 px-4 flex justify-between items-center break-all"
               >
                 <span
                   class="font-light"
@@ -192,7 +194,7 @@ exports[`renders topbar unchanged 1`] = `
         </table>
       </div>
       <label
-        class="pt-2 max-w-full break-all text-wrap"
+        class="p-2 w-full"
         id="runInfoLabel"
       >
         <input
@@ -200,193 +202,437 @@ exports[`renders topbar unchanged 1`] = `
           type="checkbox"
         />
         <span
-          class="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer"
+          class="block max-h-14 overflow-hidden rounded-lg bg-gray-50 hover:bg-gray-800 hover:text-white px-4 py-0 mb-2  shadow-lg transition-all duration-300 peer-checked/showLabel:max-h-fit cursor-pointer items-center"
         >
           <h3
-            class="flex h-14 cursor-pointer items-center font-bold "
+            class="flex h-14 cursor-pointer font-bold text-center items-center justify-center"
           >
             Show/hide all run information
           </h3>
-          <p
-            class="mb-2"
+          <div
+            class="grid md:grid-cols-5 gap-2"
           >
-            Config name
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Run state
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Run number
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Start number
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Title
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Users
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Good frames
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Raw frames (Total)
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Raw frames (Period)
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Current(uamps)
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Total(uamps)
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Monitor counts
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Monitor Spectrum
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Monitor From
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Monitor To
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Shutter Status
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Number of Spectra
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Number of Time Channels
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            DAE Simulation Mode
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Instrument Time
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Start time
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Run time
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Period
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Num periods
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Count Rate
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            RB Number
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Total Run Time
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Period Run Time
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            Period Sequence
-            : 
-          </p>
-          <p
-            class="mb-2"
-          >
-            DAE Memory Used
-            : 
-          </p>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Config name
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Run state
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Run number
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Start number
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Title
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Users
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Good frames
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Raw frames (Total)
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Raw frames (Period)
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Current(uamps)
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Total(uamps)
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Monitor counts
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Monitor Spectrum
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Monitor From
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Monitor To
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Shutter Status
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Number of Spectra
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Number of Time Channels
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                DAE Simulation Mode
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Instrument Time
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Start time
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Run time
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Period
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Num periods
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Count Rate
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                RB Number
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Total Run Time
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Period Run Time
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                Period Sequence
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+            <div
+              class="mb-2 shadow-sm rounded-md"
+            >
+              <p
+                class="font-bold"
+              >
+                DAE Memory Used
+                :
+              </p>
+               
+              <p
+                class="break-all"
+              />
+            </div>
+          </div>
         </span>
       </label>
     </div>

--- a/app/components/__snapshots__/TopBar.test.ts.snap
+++ b/app/components/__snapshots__/TopBar.test.ts.snap
@@ -7,32 +7,6 @@ exports[`renders topbar unchanged 1`] = `
     id="top_bar"
   >
     <div
-      class="text-left mb-4 p-4"
-    >
-      <h1
-        class="text-black text-2xl"
-      >
-        Instrument:
-         
-        <span
-          class="font-semibold"
-          id="instNameSpan"
-        >
-          INSTRUMENT
-        </span>
-      </h1>
-      <h1
-        class="text-black text-lg"
-      >
-        Config:
-         
-        <span
-          class="font-semibold"
-          id="configNameSpan"
-        />
-      </h1>
-    </div>
-    <div
       class="w-full flex justify-center items-center flex-col"
       id="instNameDiv"
     >
@@ -43,6 +17,7 @@ exports[`renders topbar unchanged 1`] = `
            text-black
           
           "
+        id="instNameLabel"
       >
         INSTRUMENT
          is
@@ -53,8 +28,18 @@ exports[`renders topbar unchanged 1`] = `
           UNKNOWN
         </span>
       </h2>
+      <h3
+        class="text-black text-wrap max-w-full break-all"
+      >
+        Config:
+         
+        <span
+          class="font-semibold"
+          id="configNameSpan"
+        />
+      </h3>
       <div
-        class="bg-gray-50 border-2 border-gray-800 m-4 p-4 shadow-md flex flex-col"
+        class="bg-gray-50 border-2 border-gray-800 shadow-md flex flex-col"
       >
         <table
           class="text-sm w-full table-fixed flex divide-x divide-gray-200 "
@@ -207,6 +192,7 @@ exports[`renders topbar unchanged 1`] = `
         </table>
       </div>
       <label
+        class="pt-2 max-w-full break-all text-wrap"
         id="runInfoLabel"
       >
         <input
@@ -219,7 +205,7 @@ exports[`renders topbar unchanged 1`] = `
           <h3
             class="flex h-14 cursor-pointer items-center font-bold "
           >
-            Click to show/hide all run information
+            Show/hide all run information
           </h3>
           <p
             class="mb-2"

--- a/app/types.ts
+++ b/app/types.ts
@@ -15,6 +15,7 @@ export interface IfcPV {
   alarm_low?: number;
   alarm_high?: number;
   value?: string | number;
+  updateSeconds?: number; // Seconds from epoch
 }
 
 export interface IfcBlock extends IfcPV {


### PR DESCRIPTION
Closes #68 

adds a toggle when you click a block to show "advanced information" ie. SP and last update time. removes the checkboxes above the groups. 

this also closes #55 by using a grid for the run information - thought if we were sorting layout out to be more space-efficient this would be an easy win. 

also closes #65  by fixing the width of the topbar rectangle and colouring the readback red if in alarm then showing the full alarm status on expand. 