### PR TITLE
make alarm link open in new tab

### DIFF
--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -89,6 +89,7 @@ export default function Block({
                 <a
                   href="https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Blocks#alarms"
                   className="text-red-400"
+                  target="_blank"
                 >
                   Alarm: {pv.severity}
                 </a>


### PR DESCRIPTION
this means if you expand a block and hit "alarm: x" it'll open the alarm docs in a new tab. 

to review just spin up a web dash with `npm run dev` (see readme) then find an instrument with an "alarming" block, then click it. see that the link opens in a new tab. 