### PR TITLE
fix text colour on show hidden blocks toggle

### DIFF
--- a/app/components/CheckToggle.tsx
+++ b/app/components/CheckToggle.tsx
@@ -11,7 +11,6 @@ export default function CheckToggle({
   text: string;
   textColour?: string;
 }) {
-  console.log(textColour);
   return (
     <div className="pt-4">
       <label className="inline-flex items-center cursor-pointer">

--- a/app/components/CheckToggle.tsx
+++ b/app/components/CheckToggle.tsx
@@ -11,6 +11,7 @@ export default function CheckToggle({
   text: string;
   textColour?: string;
 }) {
+  console.log(textColour);
   return (
     <div className="pt-4">
       <label className="inline-flex items-center cursor-pointer">
@@ -23,7 +24,7 @@ export default function CheckToggle({
           className="sr-only peer"
         />
         <div className="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
-        <span className={"ms-3 text-sm font-medium" + textColour}>{text}</span>
+        <span className={"ms-3 text-sm font-medium " + textColour}>{text}</span>
       </label>
     </div>
   );


### PR DESCRIPTION
This fixes the "show hidden blocks" toggle button text colour defaulting to white. this was happening because i missed a space when concatenating the text colour. whoops!

on prod see this happening and see `font-mediumtext-gray-900` - should be `font-medium text-gray-900`