### PR TITLE
make instruments more like buttons

### DIFF
--- a/app/components/InstrumentWallCard.tsx
+++ b/app/components/InstrumentWallCard.tsx
@@ -9,19 +9,17 @@ export default function InstrumentWallCard({
   instrument: IfcInstrumentStatus;
 }) {
   return (
-    <div
-      className={`flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+    <div className={"flex"}>
+      <Link
+        href={"/instrument?name=" + instrument.name}
+        target="_blank"
+        className={`flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       ${getStatusColour(instrument.runstate || "UNKNOWN")} ${getForegroundColour(
         instrument.runstate || "UNKNOWN",
       )}`}
-    >
-      <Link
-        href={"/instrument?name=" + instrument.name}
-        className="flex items-center justify-center  lg:w-20 w-full h-4"
-        target="_blank"
       >
-        <div className="flex flex-col justify-center items-center">
-          <span className="text-sm font-bold truncate line-clamp-1 ">
+        <div className="flex flex-col">
+          <span className="text-sm font-bold line-clamp-1 w-full">
             {instrument.name}
           </span>
           <span className="text-xs ">{instrument.runstate || "UNKNOWN"}</span>

--- a/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
+++ b/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`renders instrumentwallcard unchanged 1`] = `
 <div>
   <div
-    class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-[#90EE90] text-black"
+    class="flex"
   >
     <a
-      class="flex items-center justify-center  lg:w-20 w-full h-4"
+      class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-[#90EE90] text-black"
       href="/instrument?name=Instrument"
       target="_blank"
     >
       <div
-        class="flex flex-col justify-center items-center"
+        class="flex flex-col"
       >
         <span
-          class="text-sm font-bold truncate line-clamp-1 "
+          class="text-sm font-bold line-clamp-1 w-full"
         >
           Instrument
         </span>
@@ -33,19 +33,19 @@ exports[`renders instrumentwallcard unchanged 1`] = `
 exports[`renders instrumentwallcard unchanged when runstate is unknown 1`] = `
 <div>
   <div
-    class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-[#F08080] text-black"
+    class="flex"
   >
     <a
-      class="flex items-center justify-center  lg:w-20 w-full h-4"
+      class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-[#F08080] text-black"
       href="/instrument?name=Instrument1"
       target="_blank"
     >
       <div
-        class="flex flex-col justify-center items-center"
+        class="flex flex-col"
       >
         <span
-          class="text-sm font-bold truncate line-clamp-1 "
+          class="text-sm font-bold line-clamp-1 w-full"
         >
           Instrument1
         </span>

--- a/app/components/__snapshots__/ScienceGroup.test.tsx.snap
+++ b/app/components/__snapshots__/ScienceGroup.test.tsx.snap
@@ -14,19 +14,19 @@ exports[`renders sciencegroup unchanged 1`] = `
       class="flex flex-wrap gap-1"
     >
       <div
-        class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-[#90EE90] text-black"
+        class="flex"
       >
         <a
-          class="flex items-center justify-center  lg:w-20 w-full h-4"
+          class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-[#90EE90] text-black"
           href="/instrument?name=Instrument"
           target="_blank"
         >
           <div
-            class="flex flex-col justify-center items-center"
+            class="flex flex-col"
           >
             <span
-              class="text-sm font-bold truncate line-clamp-1 "
+              class="text-sm font-bold line-clamp-1 w-full"
             >
               Instrument
             </span>
@@ -39,19 +39,19 @@ exports[`renders sciencegroup unchanged 1`] = `
         </a>
       </div>
       <div
-        class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-[#DAA520] text-black"
+        class="flex"
       >
         <a
-          class="flex items-center justify-center  lg:w-20 w-full h-4"
+          class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-[#DAA520] text-black"
           href="/instrument?name=Instrument2"
           target="_blank"
         >
           <div
-            class="flex flex-col justify-center items-center"
+            class="flex flex-col"
           >
             <span
-              class="text-sm font-bold truncate line-clamp-1 "
+              class="text-sm font-bold line-clamp-1 w-full"
             >
               Instrument2
             </span>

--- a/app/components/__snapshots__/TargetStation.test.tsx.snap
+++ b/app/components/__snapshots__/TargetStation.test.tsx.snap
@@ -14,19 +14,19 @@ exports[`renders targetstation unchanged 1`] = `
       class="flex flex-wrap gap-1"
     >
       <div
-        class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-green-900 text-white"
+        class="flex"
       >
         <a
-          class="flex items-center justify-center  lg:w-20 w-full h-4"
+          class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-green-900 text-white"
           href="/instrument?name=Instrument"
           target="_blank"
         >
           <div
-            class="flex flex-col justify-center items-center"
+            class="flex flex-col"
           >
             <span
-              class="text-sm font-bold truncate line-clamp-1 "
+              class="text-sm font-bold line-clamp-1 w-full"
             >
               Instrument
             </span>
@@ -39,19 +39,19 @@ exports[`renders targetstation unchanged 1`] = `
         </a>
       </div>
       <div
-        class="flex items-center justify-between p-3  rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      bg-[#FFFF00] text-black"
+        class="flex"
       >
         <a
-          class="flex items-center justify-center  lg:w-20 w-full h-4"
+          class="flex items-center justify-center text-center p-3 min-w-28 w-auto max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
+      bg-[#FFFF00] text-black"
           href="/instrument?name=Instrument2"
           target="_blank"
         >
           <div
-            class="flex flex-col justify-center items-center"
+            class="flex flex-col"
           >
             <span
-              class="text-sm font-bold truncate line-clamp-1 "
+              class="text-sm font-bold line-clamp-1 w-full"
             >
               Instrument2
             </span>


### PR DESCRIPTION
Bit of a crap title but I wasn't sure how to summarise. 

currently if you go to https://isiscomputinggroup.github.io/WebDashboard/instruments and hover over an instrument you'll notice that only the " invisible rectangle" around the instrument name and runstate is actually click-able. This PR makes the whole "tile" more like a button, which improves UX on a touch screen primarily. 

to review follow dev instructions in the readme