### PR TITLE
show down instruments as unreachable instead of unknown

### DIFF
--- a/app/components/InstrumentWallCard.tsx
+++ b/app/components/InstrumentWallCard.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import { getForegroundColour, getStatusColour } from "./getRunstateColours";
+import {
+  getForegroundColour,
+  getStatusColour,
+  UNREACHABLE,
+} from "./getRunstateColours";
 import { instListEntryWithRunstatePVandValue } from "@/app/types";
 
 export default function InstrumentWallCard({
@@ -13,8 +17,8 @@ export default function InstrumentWallCard({
         href={"/instrument?name=" + instrument.name}
         target="_blank"
         className={`flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
-      ${getStatusColour(instrument.runStateValue || "UNKNOWN")} ${getForegroundColour(
-        instrument.runStateValue || "UNKNOWN",
+      ${getStatusColour(instrument.runStateValue || UNREACHABLE)} ${getForegroundColour(
+        instrument.runStateValue || UNREACHABLE,
       )}`}
       >
         <div className="flex flex-col">
@@ -22,7 +26,7 @@ export default function InstrumentWallCard({
             {instrument.name}
           </span>
           <span className="text-xs ">
-            {instrument.runStateValue || "UNKNOWN"}
+            {instrument.runStateValue || UNREACHABLE}
           </span>
         </div>
       </Link>

--- a/app/components/TopBar.test.ts
+++ b/app/components/TopBar.test.ts
@@ -21,7 +21,7 @@ test("GetRunstate returns the runstate when it exists and is of string type", ()
 
 test("GetRunstate returns unknown when no runstate PV in array", () => {
   const PVArr: Array<IfcPV> = [];
-  expect(getRunstate(PVArr)).toBe("UNKNOWN");
+  expect(getRunstate(PVArr)).toBe("UNREACHABLE");
 });
 
 it("renders topbar unchanged", () => {

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -1,4 +1,8 @@
-import { getForegroundColour, getStatusColour } from "./getRunstateColours";
+import {
+  getForegroundColour,
+  getStatusColour,
+  UNREACHABLE,
+} from "./getRunstateColours";
 
 import { DashboardArr, IfcPV } from "@/app/types";
 import { findPVByHumanReadableName } from "@/app/components/PVutils";
@@ -11,7 +15,7 @@ export function getRunstate(runInfoPVs: Array<IfcPV>): string {
   if (runStatePV && runStatePV.value && typeof runStatePV.value === "string") {
     return runStatePV.value;
   }
-  return "UNKNOWN";
+  return UNREACHABLE;
 }
 
 export default function TopBar({

--- a/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
+++ b/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`renders instrumentwallcard unchanged when runstate is unknown 1`] = `
         <span
           class="text-xs "
         >
-          UNKNOWN
+          UNREACHABLE
         </span>
       </div>
     </a>

--- a/app/components/__snapshots__/TopBar.test.ts.snap
+++ b/app/components/__snapshots__/TopBar.test.ts.snap
@@ -25,7 +25,7 @@ exports[`renders topbar unchanged 1`] = `
         <span
           id="runStateSpan"
         >
-          UNKNOWN
+          UNREACHABLE
         </span>
       </h2>
       <h3

--- a/app/components/getRunstateColours.test.ts
+++ b/app/components/getRunstateColours.test.ts
@@ -1,6 +1,7 @@
 import {
   getForegroundColour,
   getStatusColour,
+  UNREACHABLE,
 } from "@/app/components/getRunstateColours";
 
 test("getForegroundColor when runstate requires white text returns white text", () => {
@@ -22,7 +23,7 @@ test("getForegroundColor when runstate requires black text returns black text", 
 });
 
 test("getStatusColour when runstate unknown returns expected colour", () => {
-  const result = getStatusColour("UNKNOWN");
+  const result = getStatusColour(UNREACHABLE);
   expect(result).toBe("bg-[#F08080]");
 });
 

--- a/app/components/getRunstateColours.ts
+++ b/app/components/getRunstateColours.ts
@@ -1,3 +1,5 @@
+export const UNREACHABLE = "UNREACHABLE";
+
 const statusColourLookup = new Map<string, string>([
   ["PAUSED", "bg-red-500"],
   ["PAUSING", "bg-red-950"],
@@ -13,7 +15,7 @@ const statusColourLookup = new Map<string, string>([
 
 export function getForegroundColour(status: string): string {
   const blackTextRunstates = [
-    "UNKNOWN",
+    UNREACHABLE,
     "RUNNING",
     "PROCESSING",
     "VETOING",


### PR DESCRIPTION
I think this is more clear to the user what is going on when pvws cant reach their instrument. 