### PR TITLE
disable image optimisation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,9 @@ const nextConfig: NextConfig = {
   },
   reactStrictMode: true,
   output: "export",
+  images: {
+    unoptimized: true
+  }
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
we don't use this anyway, this is for if you're deploying to vercel and/or want to use a third party image optimisation service, we are not doing either. 

if you don't use this and try and npm run dev with nextjs 15 latest, you get a nice dev mode error as it's not supported with static output. 