### PR TITLE
Don't open instruments in new tab

### DIFF
--- a/app/components/InstrumentWallCard.tsx
+++ b/app/components/InstrumentWallCard.tsx
@@ -15,7 +15,6 @@ export default function InstrumentWallCard({
     <div className={"flex"}>
       <Link
         href={"/instrument?name=" + instrument.name}
-        target="_blank"
         className={`flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       ${getStatusColour(instrument.runStateValue || UNREACHABLE)} ${getForegroundColour(
         instrument.runStateValue || UNREACHABLE,

--- a/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
+++ b/app/components/__snapshots__/InstrumentWallCard.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`renders instrumentwallcard unchanged 1`] = `
       class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-[#90EE90] text-black"
       href="/instrument?name=Instrument"
-      target="_blank"
     >
       <div
         class="flex flex-col"
@@ -39,7 +38,6 @@ exports[`renders instrumentwallcard unchanged when runstate is unknown 1`] = `
       class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-[#F08080] text-black"
       href="/instrument?name=Instrument1"
-      target="_blank"
     >
       <div
         class="flex flex-col"

--- a/app/components/__snapshots__/ScienceGroup.test.tsx.snap
+++ b/app/components/__snapshots__/ScienceGroup.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`renders sciencegroup unchanged 1`] = `
           class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-[#90EE90] text-black"
           href="/instrument?name=Instrument"
-          target="_blank"
         >
           <div
             class="flex flex-col"
@@ -45,7 +44,6 @@ exports[`renders sciencegroup unchanged 1`] = `
           class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-[#DAA520] text-black"
           href="/instrument?name=Instrument2"
-          target="_blank"
         >
           <div
             class="flex flex-col"

--- a/app/components/__snapshots__/TargetStation.test.tsx.snap
+++ b/app/components/__snapshots__/TargetStation.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`renders targetstation unchanged 1`] = `
           class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-green-900 text-white"
           href="/instrument?name=Instrument"
-          target="_blank"
         >
           <div
             class="flex flex-col"
@@ -47,7 +46,6 @@ exports[`renders targetstation unchanged 1`] = `
           class="flex items-center justify-center text-center py-1 w-28 max-h-12 rounded-lg shadow-sm border-2 border-gray-700 dark:border-gray-200 hover:shadow-lg hover:border-black dark:hover:border-gray-700 transition-all duration-200
       bg-[#FFFF00] text-black"
           href="/instrument?name=Instrument2"
-          target="_blank"
         >
           <div
             class="flex flex-col"


### PR DESCRIPTION
It's a bit of a weird UX to open these in a new tab really, and also from the techical perspective now leaves two websockets open (one for each tab) where the user probably only needed one websocket.