### PR TITLE
Always use Europe/London timezone

### DIFF
--- a/app/components/Block.test.tsx
+++ b/app/components/Block.test.tsx
@@ -171,7 +171,7 @@ it("renders block with timestamp and shows timestamp value", () => {
   expect(
     container.querySelector(`#${aBlock.human_readable_name}_TIMESTAMP`)!
       .innerHTML,
-  ).toContain(new Date(expectedTimeStamp * 1000).toLocaleString());
+  ).toContain("11 Nov 2024, 16:20:22");
 });
 
 it("renders block without SP and hides SP value", () => {

--- a/app/components/Block.tsx
+++ b/app/components/Block.tsx
@@ -5,6 +5,12 @@ import { useState } from "react";
 const grafana_stub =
   "https://shadow.nd.rl.ac.uk/grafana/d/wMlwwaHMk/block-history?viewPanel=2&orgId=1&var-block=";
 
+const date_format = new Intl.DateTimeFormat("en-GB", {
+  dateStyle: "medium",
+  timeStyle: "medium",
+  timeZone: "Europe/London",
+});
+
 export default function Block({
   pv,
   instName,
@@ -105,7 +111,7 @@ export default function Block({
               pv.updateSeconds > minimum_date_to_be_shown ? (
                 <span id={pv.human_readable_name + "_TIMESTAMP"}>
                   {/*Multiply by 1000 here as Date() expects milliseconds*/}
-                  {`Last update: ${new Date(pv.updateSeconds * 1000).toLocaleString()}`}
+                  {`Last update: ${date_format.format(pv.updateSeconds * 1000)}`}
                 </span>
               ) : null}
             </div>


### PR DESCRIPTION
Always use `Europe/London` timezone to format block update times.

With some browser privacy settings, local timezone is hidden by the browser (and always reported as UTC). Users from elsewhere might also have different local timezone settings on their devices. Instead of using the browser-reported timezone, unconditionally use `Europe/London` time. This makes the block update times consistent with the "instrument time" reported in the banner (which is formatted server-side as London timezone).