### PR TITLE
Limit max width to 1920px

### DIFF
--- a/app/components/InstrumentData.tsx
+++ b/app/components/InstrumentData.tsx
@@ -206,7 +206,7 @@ export function InstrumentData({ instrumentName }: { instrumentName: string }) {
     return <h1>Loading...</h1>;
   }
   return (
-    <div className="p-2 w-full mx-auto">
+    <div className="p-2 w-full max-w-[1920px] mx-auto">
       <TopBar
         dashboard={currentInstrument.dashboard}
         instName={instName}


### PR DESCRIPTION
Feedback from scientist in demo, scaling was a bit weird on ultrawide screens (content scaled all the way to the edges, which is a little hard to read). Limit content width to 1920px, after which it just stays at that size and centres itself.