### PR TITLE
fix(run-info): add PERIODTYPE to hardware info dropdown

### DIFF
--- a/app/components/Instrument.ts
+++ b/app/components/Instrument.ts
@@ -152,6 +152,10 @@ export class Instrument {
           human_readable_name: "Period Sequence",
         },
         {
+          pvaddress: `${this.prefix}DAE:PERIODTYPE`,
+          human_readable_name: "Period Type",
+        },
+        {
           pvaddress: `${this.prefix}DAE:GOODFRAMES_PD`,
           human_readable_name: "Period Good Frames",
         },

--- a/app/components/__snapshots__/TopBar.test.ts.snap
+++ b/app/components/__snapshots__/TopBar.test.ts.snap
@@ -579,6 +579,20 @@ exports[`renders topbar unchanged 1`] = `
             <p
               class="font-bold"
             >
+              Period Type
+              :
+            </p>
+             
+            <p
+              class="break-all"
+            />
+          </div>
+          <div
+            class="mb-2 shadow-xs rounded-md"
+          >
+            <p
+              class="font-bold"
+            >
               Period Good Frames
               :
             </p>


### PR DESCRIPTION
## Summary

`PERIODTYPE` (`DAE:PERIODTYPE`) was missing from the `runInfoPVs` map in `Instrument.ts`, which populates the show/hide all hardware info dropdown in the TopBar. This adds it alongside the other period-related PVs so it is subscribed via websocket and displayed in the dropdown in the same way as all other run information variables.

Closes #329

## Changes

- `app/components/Instrument.ts` — added `DAE:PERIODTYPE` / "Period Type" entry to `runInfoPVs` after `PERIODSEQ`
- `app/components/__snapshots__/TopBar.test.ts.snap` — updated snapshot to include new "Period Type" row

## Test plan

- [x] `npm test` passes (84 tests, 1 snapshot updated)
- [x] "Period Type" appears in the hardware info dropdown after the fix