### PR TITLE
Make standup quicker

### DIFF
--- a/app/components/GithubActionsScheduledJobs.tsx
+++ b/app/components/GithubActionsScheduledJobs.tsx
@@ -56,10 +56,6 @@ export default function GithubActionsScheduledJobs() {
         workflowName={"lint-and-test-nightly.yml"}
       />
       <GithubActionsJob
-        repo={"ibex_bluesky_core"}
-        workflowName={"test-against-main.yml"}
-      />
-      <GithubActionsJob
         repo={"EPICS-inst_servers"}
         workflowName={"lint-and-test-nightly.yml"}
       />


### PR DESCRIPTION
This keeps causing wasted time at standup.

Keep the underlying build, but remove it from the wall display in an effort to speed up standup.